### PR TITLE
check if autoload exists before requiring it

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -1,5 +1,7 @@
 <?php
-require("../vendor/autoload.php");
+if (file_exists("../vendor/autoload.php")) {
+  require("../vendor/autoload.php");
+}
 
 // Fetch the expected config environment variables
 $lifx_access_token = getenv("LIFX_ACCESS_TOKEN");


### PR DESCRIPTION
I found that the empty `composer.json` file does not cause a vendor/autoload.php file to be created.

It might also be work removing the require() all together
